### PR TITLE
fix: change default theme in ThemeProvider from light to system 

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <div className="flex min-h-screen flex-col">
             <Navbar />
             <main className="flex-1">


### PR DESCRIPTION
# 📦 Pull Request

## 📋 Description  
Updated the `<ThemeProvider>` configuration to use the system theme as the default by setting `defaultTheme="system"`. This ensures the app initially loads using the user's OS/browser preference (light or dark mode).

Closes https://github.com/Developer-Kommunity-24/community-website/issues/20

## 🔄 Type of Change  
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🔧 Refactor  
- [ ] 📝 Documentation  

## 🧪 Testing  
Manually tested in multiple environments:
- Confirmed that the app loads in dark mode when the system is set to dark.
- Confirmed that the app loads in light mode when the system is set to light.
- Confirmed that user theme preference is respected after they toggle the theme.

## 📝 Additional Notes  
- Updated `defaultTheme` from `"light"` to `"system"` in the `ThemeProvider` props.
- `enableSystem` and `disableTransitionOnChange` remain unchanged.
