### PR TITLE
fix: only show footer animation on mount and not on scroll

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -17,8 +17,15 @@ export default function Footer() {
   const router = useRouter();
 
   useEffect(() => {
+    let triggered = false;
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
+      ([entry]) => {
+        if (entry.isIntersecting && !triggered) {
+          triggered = true;
+          setIsVisible(true);
+          observer.disconnect(); 
+        }
+      },
       { threshold: 0.1 },
     );
     const footer = document.querySelector("#footer");


### PR DESCRIPTION
# Pull Request

## 📋 Description  
fix for #49 Footer should only render on mount and not on scroll 

## 🔄 Type of Change  
<!-- Select one -->
- [x] Bug fix  
- [ ] New feature  
- [ ] Refactor  
- [ ] Documentation  

**Fix in Action**
https://github.com/user-attachments/assets/e4b86d91-b573-4e09-bbec-a50cb5ff24b0
