### PR TITLE
fix: change 'Join as a College' to 'Join as a Community' on join page

### DIFF
--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -35,7 +35,7 @@ export default function JoinUsPage() {
               <TabsTrigger value="individual">
                 Join as an Individual
               </TabsTrigger>
-              <TabsTrigger value="college">Join as a College</TabsTrigger>
+              <TabsTrigger value="college">Join as a Community</TabsTrigger>
             </TabsList>
 
             <TabsContent value="individual" className="mt-6">


### PR DESCRIPTION
# Pull Request

## 📋 Description  
change 'Join as a College' to 'Join as a Community' on join page
