### PR TITLE
prevent month/year(sep) wrapping in header

### DIFF
--- a/src/calendar/components/header/date-navigator.tsx
+++ b/src/calendar/components/header/date-navigator.tsx
@@ -42,11 +42,11 @@ export function DateNavigator({ view, events }: IProps) {
 
   return (
     <div className="space-y-0.5">
-      <div className="flex items-center gap-2">
-        <span className="text-lg font-semibold">
+      <div className="flex items-center gap-2 flex-nowrap">
+        <span className="text-lg font-semibold whitespace-nowrap">
           {month} {year}
         </span>
-        <Badge variant="outline" className="px-1.5">
+        <Badge variant="outline" className="px-1.5 whitespace-nowrap">
           {eventCount} events
         </Badge>
       </div>


### PR DESCRIPTION
<img width="784" height="123" alt="image" src="https://github.com/user-attachments/assets/afb166bf-3458-4296-89fc-1e9f5d7bd5e5" />

fixes the issue #122 
