### PR TITLE
fix wrongful message in showcase event form

### DIFF
--- a/src/components/event-submission-form.tsx
+++ b/src/components/event-submission-form.tsx
@@ -531,7 +531,7 @@ export function EventSubmissionForm() {
                 htmlFor="emailConsentChecked"
                 className="text-sm leading-relaxed cursor-pointer"
               >
-                I consent that all the details provided are correct *
+                I certify that all details are correct *
               </Label>
             </div>
             {errors.emailConsentChecked && (

--- a/src/lib/forms-config.ts
+++ b/src/lib/forms-config.ts
@@ -91,7 +91,10 @@ export const eventSubmissionSchema = z.object({
   submittedEmail: z.string().email("Please enter a valid email address."),
   emailConsentChecked: z
     .boolean()
-    .refine((val) => val === true, "You must consent that all details are correct."),
+    .refine(
+      (val) => val === true,
+      "You must certify that all details are correct.",
+    ),
   isEmailVerified: z.boolean(),
 });
 


### PR DESCRIPTION
this solves the issue #103 
the preview of the changed error message below
<img width="1086" height="212" alt="Screenshot 2026-02-27 103617" src="https://github.com/user-attachments/assets/4517804c-5b17-4bab-8d21-a87b6fc29b89" />
