### PR TITLE
Fix: Update theme toggle icon to reflect next theme state in the Footer

### DIFF
--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -26,9 +26,9 @@ export function ModeToggle() {
       className="cursor-pointer"
     >
       {isDark ? (
-        <Moon className="h-[1.2rem] w-[1.2rem] transition-transform rotate-0 scale-100" />
-      ) : (
         <Sun className="h-[1.2rem] w-[1.2rem] transition-transform rotate-0 scale-100" />
+      ) : (
+        <Moon className="h-[1.2rem] w-[1.2rem] transition-transform rotate-0 scale-100" />
       )}
     </Button>
   );


### PR DESCRIPTION
# Pull Request

## 📋 Description

Updated the theme toggle icon behavior:
1) Light mode → Displays 🌙 icon (indicates user can switch to dark mode)
2) Dark mode → Displays ☀️ icon (indicates user can switch to light mode)

This improves clarity by showing the target mode instead of the current mode.

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## 🧪 Testing

a) Verified icon updates correctly when switching between light and dark modes
b) Confirmed icon reflects the opposite theme (target theme)

## 📝 Additional Notes

* change aligns the toggle behavior with common UX patterns