### PR TITLE
feat: Edit Community Card to show both POCs and Representatives

### DIFF
--- a/src/components/community-card.tsx
+++ b/src/components/community-card.tsx
@@ -26,27 +26,66 @@ export function CommunityCard({ community }: CommunityCardProps) {
         </div>
       </div>
       <CardContent className="px-6 pb-0">
-        <p className="text-muted-foreground mb-4">{community.description}</p>
-        <div className="space-y-2 pt-4">
-          <h4 className="text-sm font-semibold">Representatives:</h4>
-          <ul className="space-y-2">
-            {community.representatives.map((rep, index) => (
-              <li key={index} className="text-sm">
-                <span className="font-medium">{rep.name}</span> - {rep.role}
-                <div className="text-sm text-muted-foreground">{rep.email}</div>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {community.description && (
+          <p className="text-muted-foreground mb-4">{community.description}</p>
+        )}
+        {((community.pocs?.length ?? 0) > 0 ||
+          (community.representatives?.length ?? 0) > 0) && (
+          <div className="space-y-6 pt-4">
+            {community.pocs && community.pocs.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="text-sm font-semibold">POCs:</h4>
+                <ul className="space-y-2">
+                  {community.pocs.map((poc, index) => (
+                    <li key={index} className="text-sm">
+                      <span className="font-medium">{poc.name}</span>
+                      {poc.role && ` - ${poc.role}`}
+                      {poc.email && (
+                        <div className="text-sm text-muted-foreground">
+                          {poc.email}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {community.representatives &&
+              community.representatives.length > 0 && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-semibold">Representatives:</h4>
+                  <ul className="space-y-2">
+                    {community.representatives.map((rep, index) => (
+                      <li key={index} className="text-sm">
+                        <span className="font-medium">{rep.name}</span>
+                        {rep.role && ` - ${rep.role}`}
+                        {rep.email && (
+                          <div className="text-sm text-muted-foreground">
+                            {rep.email}
+                          </div>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+          </div>
+        )}
       </CardContent>
-      <CardFooter className="p-6 mt-auto">
-        <Button variant="outline" className="w-full" asChild>
-          <a href={community.website} target="_blank" rel="noopener noreferrer">
-            <ExternalLink className="h-4 w-4 mr-2" />
-            Visit Website
-          </a>
-        </Button>
-      </CardFooter>
+      {community.website && (
+        <CardFooter className="p-6 mt-auto">
+          <Button variant="outline" className="w-full" asChild>
+            <a
+              href={community.website}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Visit Website
+            </a>
+          </Button>
+        </CardFooter>
+      )}
     </Card>
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,18 +11,19 @@ export type TEventColor =
 
 export interface CommunityRepresentative {
   name: string;
-  role: string;
-  email: string;
+  role?: string;
+  email?: string;
 }
 
 export interface Community {
   id: number;
   name: string;
   college: string;
-  description: string;
-  logo: string;
-  representatives: CommunityRepresentative[];
-  website: string;
+  description?: string;
+  logo?: string;
+  pocs?: CommunityRepresentative[];
+  representatives?: CommunityRepresentative[];
+  website?: string;
 }
 
 export interface Testimonial {


### PR DESCRIPTION
# Pull Request

## 📋 Description

This PR adds an enhancement to an existing feature where it shows the POCs of the community along with it's representatives.

## 🔄 Type of Change

<!-- Select one -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## 🧪 Testing

Ran the commands inside contributing.md,
`npm run lint && npm run type-check && npm run build`

## 📝 Additional Notes

The data has not been fed yet, but this is how it would look if the data was fed to it, for which I shall make another PR
<img width="671" height="826" alt="image" src="https://github.com/user-attachments/assets/5b363e85-3a1b-46e5-abf9-d2934209184e" />
