### PR TITLE
fix: update footer navigation links

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -58,12 +58,12 @@ export default function Footer() {
       { href: "/communities", label: "Member Communities" },
       { href: "/calendar", label: "Events" },
       { href: "/projects", label: "Projects" },
+      { href: "/join", label: "Join Us" },
     ],
     nav: [
-      { href: "#vision", label: "Vision" },
-      { href: "#team", label: "Team" },
-      { href: "#upcoming-events", label: "Upcoming Events" },
-      { href: "#testimonials", label: "Testimonials" },
+      { href: "/#vision", label: "Vision" },
+      { href: "/#team", label: "Team" },
+      { href: "/showcase-event", label: "Showcase Event" },
     ],
   };
 


### PR DESCRIPTION
## Description

This PR fixes the inaccurate navigation links in the footer as reported in #140.

### Changes Made

- **Removed invalid anchor links**: Removed `#upcoming-events` and `#testimonials` links that pointed to non-existent sections on the homepage
- **Updated existing anchor links**: Changed `#vision` and `#team` to `/#vision` and `/#team` to ensure they work correctly from any page
- **Added missing Quick Links**: Added `/join` (Join Us) to the Quick Links section
- **Updated Navigation section**: Replaced invalid anchor links with `/showcase-event` (Showcase Event) which is an actual page

### Verification

- Verified that all links now point to existing pages or sections
- Quick Links: /about, /structure, /communities, /calendar, /projects, /join
- Navigation: /#vision, /#team, /showcase-event

Fixes #140