### PR TITLE
fix: sort events by date and update label separators

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -164,8 +164,11 @@ export async function GET(request: NextRequest) {
         >
           {displayEvents.length > 0 ? (
             displayEvents.map((event) => {
-              const now = new Date(); // Define 'now' for use in rendering logic
-              const isEventPast = new Date(event.startDateTime) < now;
+              const now = new Date();
+              const startDate = new Date(event.startDateTime);
+              const endDate = new Date(event.endDateTime);
+              const isEventPast = now > endDate;
+              const isEventOngoing = now >= startDate && now <= endDate;
               const isDK24 = event.organizationName === "DK24";
 
               return (
@@ -337,7 +340,11 @@ export async function GET(request: NextRequest) {
                         textTransform: "uppercase",
                       }}
                     >
-                      {isEventPast ? "Completed" : "Upcoming"}
+                      {isEventPast
+                        ? "Completed"
+                        : isEventOngoing
+                          ? "Ongoing"
+                          : "Upcoming"}
                     </span>
                   </div>
                 </div>

--- a/src/components/download-ics-dialog.tsx
+++ b/src/components/download-ics-dialog.tsx
@@ -53,7 +53,15 @@ export function DownloadIcsDialog({
         getEvents(currentDate, oneYearFromNow)
           .then((data) => {
             if (!isMounted) return;
-            setEvents(Array.isArray(data) ? (data as IEvent[]) : []);
+            setEvents(
+              Array.isArray(data)
+                ? (data as IEvent[]).sort(
+                    (a, b) =>
+                      new Date(a.startDateTime).getTime() -
+                      new Date(b.startDateTime).getTime(),
+                  )
+                : [],
+            );
           })
           .catch((error) => {
             if (!isMounted) return;
@@ -161,7 +169,7 @@ export function DownloadIcsDialog({
           month: "short",
           year: "numeric",
         });
-    return monthLabel ? `${event.title} — ${monthLabel}` : event.title;
+    return monthLabel ? `${event.title} - ${monthLabel}` : event.title;
   };
 
   const toggleEvent = (eventId: string) => {

--- a/src/lib/get-events.ts
+++ b/src/lib/get-events.ts
@@ -208,7 +208,7 @@ export async function getFilteredEventsByDateRange(
   } else {
     // Current month: Show upcoming events only (if < 3, include past events)
     const upcoming = monthEvents
-      .filter((e) => new Date(e.startDateTime) >= now)
+      .filter((e) => new Date(e.endDateTime) >= now)
       .sort(
         (a, b) =>
           new Date(a.startDateTime).getTime() -

--- a/src/lib/get-events.ts
+++ b/src/lib/get-events.ts
@@ -219,7 +219,7 @@ export async function getFilteredEventsByDateRange(
       displayEvents = upcoming.slice(0, 3);
     } else {
       const past = monthEvents
-        .filter((e) => new Date(e.startDateTime) < now)
+        .filter((e) => new Date(e.endDateTime) < now)
         .sort(
           (a, b) =>
             new Date(b.startDateTime).getTime() -


### PR DESCRIPTION
# Pull Request

## 📋 Description

Adds  “ongoing” status for events and prioritizes them in previews, improves the ICS download dialog with chronological sorting.

## 🔄 Type of Change

<!-- Select one -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## 📝 Additional Notes

Maximum of 3 events are displayed and  og image updates as "ongoing" for ongoing events.

<img width="1498" height="781" alt="image" src="https://github.com/user-attachments/assets/bfed10c1-f527-46e1-8c11-4da35c32f49d" />

all the events are sorted:

<img width="627" height="575" alt="image" src="https://github.com/user-attachments/assets/32775f36-329d-46ff-96e4-f07ef742f4bb" />

Closes #135 


