### PR TITLE
fix: show correct start/end dates for inter-month events in agenda view

### DIFF
--- a/src/components/calendar/agenda-view/agenda-event-card.tsx
+++ b/src/components/calendar/agenda-view/agenda-event-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, parseISO } from "date-fns";
+import { format, isSameDay, isSameMonth, parseISO } from "date-fns";
 import { Clock, MapPin } from "lucide-react";
 import { useCalendar } from "@/components/calendar/contexts/calendar-context";
 import { Badge } from "@/components/ui/badge";
@@ -14,18 +14,29 @@ interface IProps {
 }
 
 export function AgendaEventCard({ event, className }: IProps) {
-  const { setSelectedEventId } = useCalendar();
-  const startDate = parseISO(event.startDateTime);
-  const endDate = parseISO(event.endDateTime);
+  const { setSelectedEventId, selectedDate } = useCalendar();
+  const eventStart = parseISO(event.startDateTime);
+  const eventEnd = parseISO(event.endDateTime);
 
-  const startMonth = format(startDate, "MMM");
-  const startDay = format(startDate, "d");
-  const endDay = format(endDate, "d");
-  const isSameMonth = startDate.getMonth() === endDate.getMonth();
-  const dateRange =
-    startDate.toDateString() === endDate.toDateString()
-      ? startDay
-      : `${startDay}-${isSameMonth ? endDay : format(endDate, "MMM d")}`;
+  // Determine if dates are in the currently viewed month
+  const isSameMonthStart = isSameMonth(eventStart, selectedDate);
+  const isSameMonthEnd = isSameMonth(eventEnd, selectedDate);
+
+  // Format start and end strings based on whether they are in the viewed month
+  const startStr = isSameMonthStart
+    ? format(eventStart, "d")
+    : format(eventStart, "MMM d");
+  const endStr = isSameMonthEnd
+    ? format(eventEnd, "d")
+    : format(eventEnd, "MMM d");
+
+  const isSameDayEvent = isSameDay(eventStart, eventEnd);
+  const dateRange = isSameDayEvent
+    ? format(eventStart, "d")
+    : `${startStr}-${endStr}`;
+
+  // Use the viewed month for the top badge to maintain agenda context
+  const startMonth = format(selectedDate, "MMM");
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -50,7 +61,12 @@ export function AgendaEventCard({ event, className }: IProps) {
             <span className="flex h-6 w-full items-center justify-center bg-primary text-center text-xs font-semibold text-primary-foreground">
               {startMonth}
             </span>
-            <span className="flex w-full items-center justify-center text-xl font-bold text-foreground p-2">
+            <span
+              className={cn(
+                "flex w-full items-center justify-center font-bold text-foreground p-2",
+                dateRange.length > 5 ? "text-xs px-1" : "text-xl",
+              )}
+            >
               {dateRange}
             </span>
           </div>
@@ -97,7 +113,7 @@ export function AgendaEventCard({ event, className }: IProps) {
           <div className="mt-4 flex items-center justify-end gap-1.5 text-sm font-medium text-primary sm:mt-0 sm:flex-col sm:items-end sm:justify-start sm:gap-0">
             <Clock className="size-4 sm:hidden" />
             <span className="whitespace-nowrap">
-              {format(startDate, "h:mm a")}
+              {format(eventStart, "h:mm a")}
             </span>
           </div>
         </div>

--- a/src/components/calendar/agenda-view/calendar-agenda-view.tsx
+++ b/src/components/calendar/agenda-view/calendar-agenda-view.tsx
@@ -1,4 +1,4 @@
-import { isSameMonth, parseISO } from "date-fns";
+import { endOfMonth, parseISO, startOfMonth } from "date-fns";
 import { CalendarX2 } from "lucide-react";
 import { useMemo } from "react";
 import { AgendaEventCard } from "@/components/calendar/agenda-view/agenda-event-card";
@@ -9,30 +9,46 @@ import type { IEvent } from "@/types";
 interface IProps {
   singleDayEvents: IEvent[];
   multiDayEvents: IEvent[];
+  maxVisibleEvents?: number;
 }
 
 export function CalendarAgendaView({
   singleDayEvents,
   multiDayEvents,
+  maxVisibleEvents = 5,
 }: IProps) {
   const { selectedDate } = useCalendar();
 
   const eventsForMonth = useMemo(() => {
     const allEvents = [...singleDayEvents, ...multiDayEvents];
+    const monthStart = startOfMonth(selectedDate);
+    const monthEnd = endOfMonth(selectedDate);
 
     return allEvents
       .filter((event) => {
-        const eventDate = parseISO(event.startDateTime);
-        return isSameMonth(eventDate, selectedDate);
+        const eventStart = parseISO(event.startDateTime);
+        const eventEnd = parseISO(event.endDateTime);
+        return (
+          (eventStart >= monthStart && eventStart <= monthEnd) ||
+          (eventEnd >= monthStart && eventEnd <= monthEnd) ||
+          (eventStart <= monthStart && eventEnd >= monthEnd)
+        );
       })
       .sort((a, b) => {
-        return (
-          new Date(a.startDateTime).getTime() -
-          new Date(b.startDateTime).getTime()
-        );
+        const aStart = parseISO(a.startDateTime);
+        const bStart = parseISO(b.startDateTime);
+
+        // Use effective start date for sorting (clamped to month start)
+        const aEffectiveStart = aStart < monthStart ? monthStart : aStart;
+        const bEffectiveStart = bStart < monthStart ? monthStart : bStart;
+
+        const diff = aEffectiveStart.getTime() - bEffectiveStart.getTime();
+        if (diff !== 0) return diff;
+
+        // If they start at the same time (e.g. both are ongoing), sort by original start
+        return aStart.getTime() - bStart.getTime();
       });
   }, [singleDayEvents, multiDayEvents, selectedDate]);
-
   const { isLoading, fetchError } = useCalendar();
 
   if (isLoading) {
@@ -76,17 +92,39 @@ export function CalendarAgendaView({
     );
   }
 
-  return (
-    <div className="h-full">
-      <ScrollArea className="h-full" type="always">
-        <div className="flex flex-col p-4">
+  const visibleEvents = eventsForMonth.slice(0, maxVisibleEvents);
+  const additionalEvents = eventsForMonth.slice(maxVisibleEvents);
+  const hasMoreThanVisible = additionalEvents.length > 0;
+  const hasEvents = eventsForMonth.length > 0;
+
+  const eventContent = (
+    <div className="flex flex-col p-4">
+      <div className="space-y-4">
+        {visibleEvents.map((event) => (
+          <AgendaEventCard key={event.id} event={event} />
+        ))}
+      </div>
+      {hasMoreThanVisible ? (
+        <div className="pt-4">
           <div className="space-y-4">
-            {eventsForMonth.map((event) => (
+            {additionalEvents.map((event) => (
               <AgendaEventCard key={event.id} event={event} />
             ))}
           </div>
         </div>
-      </ScrollArea>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className="h-full overflow-hidden">
+      {hasEvents ? (
+        <ScrollArea className="h-full" type="always">
+          {eventContent}
+        </ScrollArea>
+      ) : (
+        eventContent
+      )}
     </div>
   );
 }

--- a/src/components/calendar/client-container.tsx
+++ b/src/components/calendar/client-container.tsx
@@ -6,6 +6,7 @@ import { CalendarAgendaView } from "@/components/calendar/agenda-view/calendar-a
 import { useCalendar } from "@/components/calendar/contexts/calendar-context";
 import { CalendarHeader } from "@/components/calendar/header/calendar-header";
 import { CalendarMonthView } from "@/components/calendar/month-view/calendar-month-view";
+import { getMonthGridRows } from "@/lib/calendar-helpers";
 
 import type { TCalendarView } from "@/types";
 
@@ -57,6 +58,8 @@ export function ClientContainer({ view, hideHeader = false }: IProps) {
     return !isSameDay(startDate, endDate);
   });
 
+  const numRows = useMemo(() => getMonthGridRows(selectedDate), [selectedDate]);
+
   return (
     <div className="overflow-hidden rounded-xl border h-full">
       {!hideHeader && <CalendarHeader view={view} events={filteredEvents} />}
@@ -71,6 +74,7 @@ export function ClientContainer({ view, hideHeader = false }: IProps) {
         <CalendarAgendaView
           singleDayEvents={singleDayEvents}
           multiDayEvents={multiDayEvents}
+          maxVisibleEvents={numRows}
         />
       )}
     </div>

--- a/src/components/calendar/month-view/calendar-month-view.tsx
+++ b/src/components/calendar/month-view/calendar-month-view.tsx
@@ -34,8 +34,8 @@ export function CalendarMonthView({ singleDayEvents, multiDayEvents }: IProps) {
   );
 
   return (
-    <Card className="bg-linear-to-br from-green-50/50 to-white dark:from-green-950/20 dark:to-background border-green-200/50 dark:border-green-800/50 py-0 h-full">
-      <CardContent className="p-4 h-full">
+    <Card className="bg-linear-to-br from-green-50/50 to-white dark:from-green-950/20 dark:to-background border-green-200/50 dark:border-green-800/50 py-0">
+      <CardContent className="p-4">
         {fetchError ? (
           <div className="mb-4 text-sm text-destructive border border-destructive/30 bg-destructive/5 rounded-md p-3">
             {fetchError}

--- a/src/components/calendar/month-view/month-event-badge.tsx
+++ b/src/components/calendar/month-view/month-event-badge.tsx
@@ -1,7 +1,14 @@
 "use client";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
-import { endOfDay, isSameDay, parseISO, startOfDay } from "date-fns";
+import {
+  differenceInCalendarDays,
+  endOfDay,
+  isSameDay,
+  parseISO,
+  startOfDay,
+  startOfMonth,
+} from "date-fns";
 import { Star } from "lucide-react";
 import { type RefObject, useEffect, useRef } from "react";
 import { useCalendar } from "@/components/calendar/contexts/calendar-context";
@@ -55,14 +62,6 @@ const eventBadgeVariants = cva(
   },
 );
 
-function daysBetween(dateStr1: Date, dateStr2: Date) {
-  const d1 = new Date(dateStr1);
-  const d2 = new Date(dateStr2);
-  return Math.floor(
-    Math.abs((d2.getTime() - d1.getTime()) / (1000 * 60 * 60 * 24)),
-  );
-}
-
 interface IProps
   extends Omit<
     VariantProps<typeof eventBadgeVariants>,
@@ -86,9 +85,13 @@ export function MonthEventBadge({
   className,
   position: propPosition,
 }: IProps) {
+  const { selectedDate } = useCalendar();
   const textRef = useRef<HTMLParagraphElement | null>(null);
   const itemStart = startOfDay(parseISO(event.startDateTime));
   const itemEnd = endOfDay(parseISO(event.endDateTime));
+
+  const monthStart = startOfMonth(selectedDate);
+  const effectiveStart = itemStart < monthStart ? monthStart : itemStart;
 
   useEffect(() => {
     const badgeContainer = badgeContainerRef.current;
@@ -98,8 +101,7 @@ export function MonthEventBadge({
 
     const observer = new ResizeObserver(() => {
       const btnWidth = badgeContainer.offsetWidth;
-      const cellIndex =
-        daysBetween(itemStart, itemEnd) - daysBetween(cellDate, itemEnd);
+      const cellIndex = differenceInCalendarDays(cellDate, effectiveStart);
       const isSunday = Boolean(cellDate.getDay());
 
       text.style.transform = `translateX(${-btnWidth * cellIndex + (cellIndex > 0 ? 13 - cellIndex + (isSunday ? 2 : 0) : 0)}px)`;
@@ -108,7 +110,7 @@ export function MonthEventBadge({
     observer.observe(badgeContainer);
 
     return () => observer.disconnect();
-  }, [badgeContainerRef, cellDate, itemStart, itemEnd]);
+  }, [badgeContainerRef, cellDate, effectiveStart]);
 
   const {
     badgeVariant,
@@ -127,7 +129,10 @@ export function MonthEventBadge({
     position = "none";
   } else if (isSameDay(itemStart, itemEnd)) {
     position = "none";
-  } else if (isSameDay(cellDate, itemStart)) {
+  } else if (
+    isSameDay(cellDate, itemStart) ||
+    (isSameDay(cellDate, monthStart) && itemStart < monthStart)
+  ) {
     position = "first";
   } else if (isSameDay(cellDate, itemEnd)) {
     position = "last";

--- a/src/components/events-tabs.tsx
+++ b/src/components/events-tabs.tsx
@@ -3,6 +3,7 @@
 import { Calendar, Plus } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { ClientContainer } from "@/components/calendar/client-container";
 import { DownloadIcsDialog } from "@/components/download-ics-dialog";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,21 @@ export function EventsTabs() {
     autoTrackPageView: false,
     autoTrackMonthChange: false,
   });
+
+  const monthRef = useRef<HTMLDivElement>(null);
+  const [monthHeight, setMonthHeight] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (monthRef.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          setMonthHeight(entry.contentRect.height);
+        }
+      });
+      resizeObserver.observe(monthRef.current);
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
 
   const handleViewChange = (view: string) => {
     if (view === "month" || view === "agenda") {
@@ -68,11 +84,14 @@ export function EventsTabs() {
         </div>
 
         {/* Desktop View: Side-by-Side */}
-        <div className="hidden lg:flex lg:gap-6 items-stretch">
-          <div className="lg:w-1/2">
+        <div className="hidden lg:flex lg:gap-6 items-start">
+          <div
+            className="lg:w-1/2"
+            style={monthHeight ? { height: monthHeight } : undefined}
+          >
             <ClientContainer view="agenda" hideHeader={true} />
           </div>
-          <div className="lg:w-1/2">
+          <div className="lg:w-1/2" ref={monthRef}>
             <ClientContainer view="month" />
           </div>
         </div>

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -94,9 +94,26 @@ export function getEventsCount(
     month: isSameMonth,
   };
 
-  return events.filter((event) =>
-    compareFns[view](new Date(event.startDateTime), date),
-  ).length;
+  return events.filter((event) => {
+    const eventStart = new Date(event.startDateTime);
+    const eventEnd = new Date(event.endDateTime);
+
+    if (view === "month" || view === "agenda") {
+      const monthStart = new Date(date.getFullYear(), date.getMonth(), 1);
+      const monthEnd = new Date(
+        date.getFullYear(),
+        date.getMonth() + 1,
+        0,
+        23,
+        59,
+        59,
+        999,
+      );
+      return eventStart <= monthEnd && eventEnd >= monthStart;
+    }
+
+    return compareFns[view](eventStart, date);
+  }).length;
 }
 
 export function getCurrentEvents(events: IEvent[]) {
@@ -243,6 +260,21 @@ export function getCalendarCells(selectedDate: Date): ICalendarCell[] {
   );
 
   return [...prevMonthCells, ...currentMonthCells, ...nextMonthCells];
+}
+
+export function getMonthGridRows(selectedDate: Date): number {
+  const firstDayOfMonth = new Date(
+    selectedDate.getFullYear(),
+    selectedDate.getMonth(),
+    1,
+  ).getDay();
+  const daysInMonth = new Date(
+    selectedDate.getFullYear(),
+    selectedDate.getMonth() + 1,
+    0,
+  ).getDate();
+  const totalCells = firstDayOfMonth + daysInMonth;
+  return Math.ceil(totalCells / 7);
 }
 
 export function calculateMonthEventPositions(


### PR DESCRIPTION
- Display actual event start/end dates instead of clamping to current month
- Show "MMM d - MMM d" format for events spanning multiple months
- Sync height between month and agenda views on desktop using ResizeObserver
- Limit visible events in agenda to match month grid rows
- Update event count to include ongoing events from previous/next months

Closes #150 