### PR TITLE
fix: adjust month view day cell height for event display

### DIFF
--- a/src/components/calendar/month-view/day-cell.tsx
+++ b/src/components/calendar/month-view/day-cell.tsx
@@ -49,7 +49,7 @@ export function DayCell({ cell, events, eventPositions }: IProps) {
 
       <div
         className={cn(
-          "flex min-h-10 flex-col gap-1 lg:h-15.5 lg:gap-2 px-0",
+          "flex min-h-14 flex-col gap-1 lg:h-15.5 lg:gap-2 px-0",
           !currentMonth && "opacity-50",
         )}
       >
@@ -62,7 +62,7 @@ export function DayCell({ cell, events, eventPositions }: IProps) {
           return (
             <div
               key={eventKey}
-              className="lg:flex-1 w-full"
+              className="flex-1 w-full"
               ref={badgeContainerRef}
             >
               {event && (


### PR DESCRIPTION
- Increase min-height from min-h-10 to min-h-14 for better event display
- Apply flex-1 to event badge containers on all screen sizes

closes #151 